### PR TITLE
[sailjail-permissions] Add audioroute service to Audio permissions. Contributes to JB#52175

### DIFF
--- a/permissions/Audio.permission
+++ b/permissions/Audio.permission
@@ -22,3 +22,7 @@ dbus-user.own org.mpris.MediaPlayer2.*
 dbus-system.talk org.maemo.resource.manager
 dbus-system.broadcast org.maemo.resource.manager=org.maemo.resource.manager.*@/*
 # END systembus-org.maemo.resource.manager.resource
+
+# BEG systembus-org.nemomobile.Route.Manager
+dbus-system.talk org.nemomobile.Route.Manager
+# END systembus-org.nemomobile.Route.Manager


### PR DESCRIPTION
Needed by fm radio support.

@rainemak @Tomin1 