### PR TITLE
[sailjail-permission] Allow talking to store. Fixes JB#52224

### DIFF
--- a/permissions/Email.permission
+++ b/permissions/Email.permission
@@ -44,3 +44,6 @@ include /etc/sailjail/permissions/MediaIndexing.permission
 # Global address list
 dbus-user.talk org.sailfishos.easdaemon
 dbus-user.broadcast org.sailfishos.easdaemon=org.sailfishos.easdaemon.*@/*
+
+# Launch store for email app installation if not already installed
+dbus-user.talk com.jolla.jollastore


### PR DESCRIPTION
Launch store for email app installation if not already installed.