### PR TITLE
[permissions] Add jolla-settings to Phone permissions. Fixes JB#52483

### DIFF
--- a/permissions/Phone.permission
+++ b/permissions/Phone.permission
@@ -45,3 +45,7 @@ include /etc/sailjail/permissions/Audio.permission
 # Allow requesting sim pin
 dbus-user.talk com.jolla.PinQuery
 dbus-user.broadcast com.jolla.PinQuery=com.jolla.PinQuery.*@/*
+
+# BEG sessionbus-com.jolla.settings
+dbus-user.call com.jolla.settings=com.jolla.settings.ui.*@/*
+# END sessionbus-com.jolla.settings


### PR DESCRIPTION
Phone app can show about page with *#07# and needs to call
settings d-bus for that.

@rainemak @Tomin1 