### PR TITLE
[permissions] Add thumbnail helper binaries to private-bin. JB#52400

### DIFF
--- a/permissions/Thumbnails.permission
+++ b/permissions/Thumbnails.permission
@@ -17,3 +17,7 @@ whitelist ${HOME}/.cache/org.nemomobile/thumbnails
 dbus-user.talk org.nemomobile.Thumbnailer
 dbus-user.broadcast org.nemomobile.Thumbnailer=org.nemomobile.Thumbnailer.*@/*
 # END sessionbus-org.nemomobile.Thumbnailer.resource
+
+# libnemothumbnailer-qt5 might execute helper binaries instead
+# of using dbus interface for handling pdf and video files
+private-bin thumbnaild-pdf,thumbnaild-video


### PR DESCRIPTION
Generating thumbnails for some file types is handled by library code
executing helper binaries (instead of using thumbnailer D-Bus service).
To facilitate this, the helper binaries must be visible to the sandboxed
application.

Add pdf and video thumbnail helpers to private-bin list.

Signed-off-by: Simo Piiroinen <simo.piiroinen@jolla.com>