### PR TITLE
[permissions] Add common Android directories to permissions. Fixes JB#52685

### DIFF
--- a/permissions/Downloads.permission
+++ b/permissions/Downloads.permission
@@ -8,3 +8,5 @@
 
 mkdir     ${HOME}/Downloads
 whitelist ${HOME}/Downloads
+
+whitelist ${HOME}/android_storage/Download

--- a/permissions/Music.permission
+++ b/permissions/Music.permission
@@ -14,3 +14,6 @@ whitelist ${HOME}/Playlists
 
 mkdir     ${HOME}/.cache/media-art
 whitelist ${HOME}/.cache/media-art
+
+whitelist ${HOME}/android_storage/Music
+whitelist ${HOME}/android_storage/Podcasts

--- a/permissions/Pictures.permission
+++ b/permissions/Pictures.permission
@@ -9,4 +9,7 @@
 mkdir     ${HOME}/Pictures
 whitelist ${HOME}/Pictures
 
+whitelist ${HOME}/android_storage/Pictures
+whitelist ${HOME}/android_storage/DCIM
+
 include /etc/sailjail/permissions/Thumbnails.permission


### PR DESCRIPTION
Add music, download and picture directories from android_storage that are indexed by Tracker to relevant permissions. Don't create them if they don't yet exist.