### PR TITLE
[sailjail-permissions] Add office profile to allow SQlite storage.

### DIFF
--- a/permissions/sailfish-office.profile
+++ b/permissions/sailfish-office.profile
@@ -1,0 +1,13 @@
+# -*- mode: sh -*-
+
+# Firejail profile for /usr/bin/sailfish-office
+
+# x-sailjail-translation-catalog =
+# x-sailjail-translation-key-description =
+# x-sailjail-description = Execute sailfish-office application
+# x-sailjail-translation-key-long-description =
+# x-sailjail-long-description =
+
+### APPLICATION
+mkdir     ${HOME}/.local/share/Sailfish/Sailfish Office
+whitelist ${HOME}/.local/share/Sailfish/Sailfish Office


### PR DESCRIPTION
Sailfish-office is using a QML local storage to store last open position for documents. The path where this QML storage is located is not allowed by sailjail at the moment. This MR correct it.

@pvuorela,  you may want to standardize the location, using `sailfishos.org` or something similar instead of `Sailfish`. We need an additional MR in sailfish-office for this. What do you think ?