### PR TITLE
[sailjail-permissions] Add config file to Calendar permission. Contributes to JB#51280

### DIFF
--- a/permissions/Calendar.permission
+++ b/permissions/Calendar.permission
@@ -13,3 +13,7 @@ privileged-data Calendar
 
 mkdir     ${PRIVILEGED}/autofill
 privileged-data autofill
+
+mkdir     ${HOME}/.config/nemo
+whitelist ${HOME}/.config/nemo
+whitelist ${HOME}/.config/nemo/nemo-qml-plugin-calendar.conf


### PR DESCRIPTION
The calendar application can make use of a configuration file which
stores e.g. calendar colour information.