### PR TITLE
[permissions] Add dbus interface access to calendar permissions. Contributes to JB#52660

### DIFF
--- a/permissions/Calendar.permission
+++ b/permissions/Calendar.permission
@@ -13,3 +13,6 @@ privileged-data Calendar
 
 mkdir     ${PRIVILEGED}/autofill
 privileged-data autofill
+
+# Trigger calendar event view or import
+dbus-user.talk com.jolla.calendar.ui

--- a/permissions/jolla-email.profile
+++ b/permissions/jolla-email.profile
@@ -17,6 +17,7 @@
 # x-sailjail-permission = Privileged
 # x-sailjail-permission = Internet
 # x-sailjail-permission = Connman
+# x-sailjail-permission = Calendar
 # for starting messageserver5
 # x-sailjail-permission = AppLaunch
 


### PR DESCRIPTION
The jolla-calendar app exposes a dbus interface that allows calendar
entries to be viewed and ics events to be imported.

This change allows apps with Calendar permissions access to this dbus
interface.