### PR TITLE
[permissions] Remove notification database access. Fixes JB#52765

### DIFF
--- a/permissions/Notifications.permission
+++ b/permissions/Notifications.permission
@@ -8,11 +8,6 @@
 
 whitelist /usr/share/lipstick-jolla-home-qt5/notifications
 
-# FIXME: we probably should not expose privileged dirs here
-#        does app even need fs access? lipstick does it?
-mkdir     ${PRIVILEGED}/Notifications
-privileged-data Notifications
-
 # BEG sessionbus-org.freedesktop.Notifications.resource
 dbus-user.talk org.freedesktop.Notifications
 dbus-user.broadcast org.freedesktop.Notifications=org.freedesktop.Notifications.*@/*


### PR DESCRIPTION
This should be only needed by Lipstick for storing the notifications.

@Tomin1 