### PR TITLE
Add a profile to allow GnuPG crypto operations

### DIFF
--- a/permissions/Base.permission
+++ b/permissions/Base.permission
@@ -18,6 +18,9 @@ writable-run-user
 # we use "private-etc selinux" -> must not blacklist it
 noblacklist /etc/selinux
 
+# we need to be able to whitelist it later, while it's in disable-common.inc
+noblacklist ${HOME}/.gnupg
+
 # Persistent local customizations
 # Persistent global definitions
 #include globals.local

--- a/permissions/Email.permission
+++ b/permissions/Email.permission
@@ -44,6 +44,9 @@ include /etc/sailjail/permissions/SyncFW.permission
 # Media Indexing for above
 include /etc/sailjail/permissions/MediaIndexing.permission
 
+# Sign emails with GnuPG
+include /etc/sailjail/permissions/GnuPG.permission
+
 # Global address list
 dbus-user.talk org.sailfishos.easdaemon
 dbus-user.broadcast org.sailfishos.easdaemon=org.sailfishos.easdaemon.*@/*

--- a/permissions/GnuPG.permission
+++ b/permissions/GnuPG.permission
@@ -1,0 +1,14 @@
+# -*- mode: sh -*-
+
+# x-sailjail-translation-catalog =
+# x-sailjail-translation-key-description =
+# x-sailjail-description = GnuPG
+# x-sailjail-translation-key-long-description =
+# x-sailjail-long-description = Use cryptographic operations with GnuPG
+
+mkdir     ${HOME}/.gnupg
+whitelist ${HOME}/.gnupg
+
+private-bin gpg2
+private-bin gpg-agent
+private-bin pinentry

--- a/permissions/jolla-email.profile
+++ b/permissions/jolla-email.profile
@@ -18,6 +18,7 @@
 # x-sailjail-permission = Internet
 # x-sailjail-permission = Connman
 # x-sailjail-permission = Calendar
+# x-sailjail-permission = GnuPG
 # for starting messageserver5
 # x-sailjail-permission = AppLaunch
 


### PR DESCRIPTION
Fixes #15.

@spiiroin and @pvuorela this would allow to use crypto operations in jolla-email. It still requires to add the GnuPG permission to the jolla-email desktop file though.

Before the patch, you cannot sign an outgoing email.