### PR TITLE
[sailjail-permissions] Add Keys dir to Accounts. Contributes to JB#52867

### DIFF
--- a/permissions/Accounts.permission
+++ b/permissions/Accounts.permission
@@ -14,6 +14,9 @@ whitelist /usr/share/libsailfishkeyprovider/storedkeys.ini
 mkdir     ${PRIVILEGED}/Accounts
 privileged-data Accounts
 
+mkdir     ${PRIVILEGED}/Keys
+privileged-data Keys
+
 mkdir     ${HOME}/.local/share/accounts
 whitelist ${HOME}/.local/share/accounts
 


### PR DESCRIPTION
The keyprovider system used by some gallery plugins has user written
configuration here. Could be good to allow even if the static
data is commonly used.

@Tomin1 @rainemak 