### PR TITLE
[sailjail-permissions] Add dsme to voicecall permissions. Fixes JB#53293

### DIFF
--- a/permissions/voicecall-ui.profile
+++ b/permissions/voicecall-ui.profile
@@ -16,3 +16,5 @@ whitelist /usr/share/voicecall-ui-jolla
 
 dbus-system.talk org.nemomobile.provisioning
 dbus-system.broadcast org.nemomobile.provisioning=org.nemomobile.provisioning.interface.*@/
+
+dbus-system.call com.nokia.dsme=com.nokia.dsme.request.*@/com/nokia/dsme/request


### PR DESCRIPTION
Voicecall error dialog can request device reboot, needs dsme.

@Tomin1 