### PR TITLE
Call recorder permissions for Phone

### DIFF
--- a/permissions/Phone.permission
+++ b/permissions/Phone.permission
@@ -49,3 +49,9 @@ dbus-user.broadcast com.jolla.PinQuery=com.jolla.PinQuery.*@/*
 # BEG sessionbus-com.jolla.settings
 dbus-user.call com.jolla.settings=com.jolla.settings.ui.*@/*
 # END sessionbus-com.jolla.settings
+
+mkdir     ${PRIVILEGED}/Phone
+privileged-data Phone
+
+mkdir     ${PRIVILEGED}/Phone/CallRecordings
+privileged-data Phone/CallRecordings


### PR DESCRIPTION
It seems the call recording function cannot store the audio files.
This is my attempt to give the phone app the required permissions.

Not sure if this should go into Phone.permissions or voicecall-ui though