### PR TITLE
Default to "net none"

### DIFF
--- a/permissions/Base.permission
+++ b/permissions/Base.permission
@@ -132,11 +132,12 @@ dbus-user.broadcast com.nokia.time=com.nokia.time.*@/*
 # BEG sessionbus-org.maliit.server.resource
 dbus-user.talk org.maliit.server
 dbus-user.broadcast org.maliit.server=org.maliit.server.*@/*
+read-only ${RUNUSER}/maliit-server
 # END sessionbus-org.maliit.server.resource
 
 ### network
 protocol unix
-# net none <== can't be used as "net none" breaks maliit
+net none
 
 ### environment
 shell none

--- a/permissions/Internet.permission
+++ b/permissions/Internet.permission
@@ -8,6 +8,7 @@
 
 # XXX: does "netlink" really belong here?
 ### network
+ignore net none
 protocol inet,inet6,netlink
 #net eth0
 #netfilter


### PR DESCRIPTION
Now that maliit uses regular unix socket instead of an abstract one,
applications can be put into private net namespaces via "net none".
    
Which then needs to be undone for those applications that have been
granted internet access.
    
