### PR TITLE
Hide well-known directories by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,18 @@ to match the declaration added to the desktop file.
     app->setApplicationName(QStringLiteral("myapp"));
     ...
 
-In future this will be done automatically by the Sailfish App library (libsailfishapp).
+When Sailfish App library (libsailfishapp) is used these values are set automatically to the values
+set in desktop file.
+
+### Files shared with other applications
+
+Well-known directories such as Documents, Downloads, Music, Pictures and Videos contain files that
+are available for applications with respective permissions. Those directories must be used when the
+data needs to be accessible by other applications.
+
+If application doesn't have a permission for a directory, all data in that directory will be hidden
+and the application sees only an empty read-only directory in that path. This allows to regular file
+access checks to function in expected way.
 
 ## Permissions
 

--- a/permissions/Base.permission
+++ b/permissions/Base.permission
@@ -167,3 +167,20 @@ privileged-data -
 ### Qt's logging rules
 whitelist ${HOME}/.config/QtProject/qtlogging.ini
 read-only ${HOME}/.config/QtProject/qtlogging.ini
+
+### Disable access to well-known directories
+# These rules say that there is an empty read-only directory inside
+# sandbox. They are prevented separately for each directory with
+# noblacklist rule in their respective permission file
+mkdir     ${HOME}/Documents
+blacklist ${HOME}/Documents
+mkdir     ${HOME}/Downloads
+blacklist ${HOME}/Downloads
+mkdir     ${HOME}/Pictures
+blacklist ${HOME}/Pictures
+mkdir     ${HOME}/Playlists
+blacklist ${HOME}/Playlists
+mkdir     ${HOME}/Music
+blacklist ${HOME}/Music
+mkdir     ${HOME}/Videos
+blacklist ${HOME}/Videos

--- a/permissions/Documents.permission
+++ b/permissions/Documents.permission
@@ -6,6 +6,8 @@
 # x-sailjail-translation-key-long-description = permission-la-documents_description
 # x-sailjail-long-description = Use stored document files
 
-mkdir     ${HOME}/Documents
-whitelist ${HOME}/Documents
+mkdir       ${HOME}/Documents
+noblacklist ${HOME}/Documents
+whitelist   ${HOME}/Documents
+
 whitelist ${HOME}/android_storage/Documents

--- a/permissions/Downloads.permission
+++ b/permissions/Downloads.permission
@@ -6,7 +6,8 @@
 # x-sailjail-translation-key-long-description = permission-la-downloads_description
 # x-sailjail-long-description = Use downloaded files
 
-mkdir     ${HOME}/Downloads
-whitelist ${HOME}/Downloads
+mkdir       ${HOME}/Downloads
+noblacklist ${HOME}/Downloads
+whitelist   ${HOME}/Downloads
 
 whitelist ${HOME}/android_storage/Download

--- a/permissions/Music.permission
+++ b/permissions/Music.permission
@@ -6,11 +6,13 @@
 # x-sailjail-translation-key-long-description = permission-la-music_description
 # x-sailjail-long-description = Use stored music files
 
-mkdir     ${HOME}/Music
-whitelist ${HOME}/Music
+mkdir       ${HOME}/Music
+noblacklist ${HOME}/Music
+whitelist   ${HOME}/Music
 
-mkdir     ${HOME}/Playlists
-whitelist ${HOME}/Playlists
+mkdir       ${HOME}/Playlists
+noblacklist ${HOME}/Playlists
+whitelist   ${HOME}/Playlists
 
 mkdir     ${HOME}/.cache/media-art
 whitelist ${HOME}/.cache/media-art

--- a/permissions/Pictures.permission
+++ b/permissions/Pictures.permission
@@ -6,8 +6,9 @@
 # x-sailjail-translation-key-long-description = permission-la-pictures_description
 # x-sailjail-long-description = Use stored picture files
 
-mkdir     ${HOME}/Pictures
-whitelist ${HOME}/Pictures
+mkdir       ${HOME}/Pictures
+noblacklist ${HOME}/Pictures
+whitelist   ${HOME}/Pictures
 
 whitelist ${HOME}/android_storage/Pictures
 whitelist ${HOME}/android_storage/DCIM

--- a/permissions/Videos.permission
+++ b/permissions/Videos.permission
@@ -6,8 +6,9 @@
 # x-sailjail-translation-key-long-description = permission-la-videos_description
 # x-sailjail-long-description = Use stored video files
 
-mkdir     ${HOME}/Videos
-whitelist ${HOME}/Videos
+mkdir       ${HOME}/Videos
+noblacklist ${HOME}/Videos
+whitelist   ${HOME}/Videos
 
 # Android storage
 whitelist ${HOME}/android_storage/Movies


### PR DESCRIPTION
Hide well-know directories by default. These rules mount an empty
read-only directory on top of well-known directories unless the
respective permissions have been granted. Update documentation about
these rules. Also mention that libsailfishapp will set OrganizationName
and ApplicationName correctly.