### PR TITLE
Add user common dirs permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ OrganizationName and ApplicationName is used for granting for the application wr
 Access above directories from the application through QStandardPaths
 1. Application data location - QStandardPaths::writableLocation(QStandardPaths::AppDataLocation)
 2. Application cache location - QStandardPaths::writableLocation(QStandardPaths::CacheLocation)
-3. Application config location  - QStandardPaths::writableLocation(QStandardPaths::CacheLocation)
+3. Application config location  - QStandardPaths::writableLocation(QStandardPaths::ConfigLocation)
 
 Only these directories can be used for storing application specific data that needs to persist over
 application restarts.
@@ -80,7 +80,7 @@ set in desktop file.
 
 ### Files shared with other applications
 
-Well-known directories such as Documents, Downloads, Music, Pictures and Videos contain files that
+Directories under user home such as Documents, Downloads, Music, Pictures and Videos contain files that
 are available for applications with respective permissions. Those directories must be used when the
 data needs to be accessible by other applications.
 
@@ -115,8 +115,10 @@ Permissions that applications may use (names are subject to change):
 | Music | Access to Music directory, playlists and coverart cache. |
 | Phone | Make Phone calls, either directly or through system voice call UI. |
 | Pictures | Access to Pictures directory and thumbnails. |
+| PublicDir | Access to Public directory. |
 | Sharing | Use of sharing pages in the application to share data via Bluetooth, email or other accounts. |
 | Synchronization | Access to synchronization framework. |
+| UserDirs | Access to Documents, Downloads, Music, Pictures, Public and Video directories. |
 | Videos | Access to Videos directory and thumbnails. |
 
 Internal permissions that applications generally should not use directly:

--- a/permissions/Base.permission
+++ b/permissions/Base.permission
@@ -169,10 +169,12 @@ privileged-data -
 whitelist ${HOME}/.config/QtProject/qtlogging.ini
 read-only ${HOME}/.config/QtProject/qtlogging.ini
 
-### Disable access to well-known directories
+### Disable access to well-known directories (XDG user directories) by default
 # These rules say that there is an empty read-only directory inside
 # sandbox. They are prevented separately for each directory with
 # noblacklist rule in their respective permission file
+mkdir     ${HOME}/Desktop
+blacklist ${HOME}/Desktop
 mkdir     ${HOME}/Documents
 blacklist ${HOME}/Documents
 mkdir     ${HOME}/Downloads
@@ -185,3 +187,7 @@ mkdir     ${HOME}/Music
 blacklist ${HOME}/Music
 mkdir     ${HOME}/Videos
 blacklist ${HOME}/Videos
+mkdir     ${HOME}/Public
+blacklist ${HOME}/Public
+mkdir     ${HOME}/Templates
+blacklist ${HOME}/Templates

--- a/permissions/PublicDir.permission
+++ b/permissions/PublicDir.permission
@@ -1,0 +1,11 @@
+# -*- mode: sh -*-
+
+# x-sailjail-translation-catalog = sailjail-permissions
+# x-sailjail-translation-key-description = permission-la-publicdir
+# x-sailjail-description = Public directory
+# x-sailjail-translation-key-long-description = permission-la-publicdir_description
+# x-sailjail-long-description = Access Public directory
+
+mkdir       ${HOME}/Public
+noblacklist ${HOME}/Public
+whitelist   ${HOME}/Public

--- a/permissions/UserDirs.permission
+++ b/permissions/UserDirs.permission
@@ -1,0 +1,20 @@
+# -*- mode: sh -*-
+
+# x-sailjail-translation-catalog = sailjail-permissions
+# x-sailjail-translation-key-description = permission-la-userdirs
+# x-sailjail-description = User directories
+# x-sailjail-translation-key-long-description = permission-la-userdirs_description
+# x-sailjail-long-description = Access common user directories
+
+include /etc/sailjail/permissions/Documents.permission
+
+include /etc/sailjail/permissions/Downloads.permission
+
+include /etc/sailjail/permissions/Music.permission
+
+include /etc/sailjail/permissions/Pictures.permission
+
+include /etc/sailjail/permissions/PublicDir.permission
+
+include /etc/sailjail/permissions/Videos.permission
+


### PR DESCRIPTION
Use includes to add permissions to `Downloads`, `Documents`, `Music`, `Pictures` and `Videos`. In addition include the common user directory `Public` but exclude `Templates` as unneeded and `Desktop` as not wanted our desktop files are handled differently.

Also fix a copy-paste error in `README.md`.