### PR TITLE
Adjust qmf socket path.

### DIFF
--- a/permissions/Base.permission
+++ b/permissions/Base.permission
@@ -30,6 +30,10 @@ include disable-passwdmgr.inc
 # include disable-programs.inc
 # include disable-xdg.inc
 
+# Runuser blacklisting
+mkdir     ${RUNUSER}/messageserver
+blacklist ${RUNUSER}/messageserver
+
 ### home directory whitelisting
 whitelist ${HOME}/.cursors/default
 whitelist ${HOME}/.local/share/glib-2.0/schemas

--- a/permissions/Email.permission
+++ b/permissions/Email.permission
@@ -19,7 +19,8 @@ mkdir     ${HOME}/Downloads/mail_attachments
 whitelist ${HOME}/Downloads/mail_attachments
 
 # MessageServer socket
-whitelist /tmp/qcop-server-0
+noblacklist ${RUNUSER}/messageserver
+read-only   ${RUNUSER}/messageserver
 
 # Messaging framework
 mkdir     ${HOME}/.qmf


### PR DESCRIPTION
Messageserver (qmf) socket was moved to RUNUSER directory and rules need
adapting to that. Blacklist it by default so that applications without
access to email can't use it.