### PR TITLE
Remove application specific paths from Email.permission

### DIFF
--- a/permissions/Email.permission
+++ b/permissions/Email.permission
@@ -6,18 +6,6 @@
 # x-sailjail-translation-key-long-description = permission-la-email_description
 # x-sailjail-long-description = Read and send email
 
-whitelist /usr/share/jolla-settings/pages/jolla-email
-whitelist /usr/share/jolla-email
-
-mkdir     ${HOME}/.cache/jolla-email
-whitelist ${HOME}/.cache/jolla-email
-
-mkdir     ${HOME}/.local/share/jolla-email
-whitelist ${HOME}/.local/share/jolla-email
-
-mkdir     ${HOME}/Downloads/mail_attachments
-whitelist ${HOME}/Downloads/mail_attachments
-
 # MessageServer socket
 noblacklist ${RUNUSER}/messageserver
 read-only   ${RUNUSER}/messageserver
@@ -54,5 +42,6 @@ dbus-user.broadcast org.sailfishos.easdaemon=org.sailfishos.easdaemon.*@/*
 mkdir     ${PRIVILEGED}/eas-sailfish
 privileged-data eas-sailfish
 
+# TODO: Remove once sharing does not depend on this permission
 # Launch store for email app installation if not already installed
 dbus-user.talk com.jolla.jollastore


### PR DESCRIPTION
Remove application specific paths from Email.permission. These are
either legacy and not used anymore, were never used, or they are
automatically allowed by sailjail.

Those mail_attachments rules didn't do anything as the directory access
is allowed anyway if app has Downloads permission. Also added a comment
about that dbus rule.