### PR TITLE
Split UDisk2 permissions, Use disable-mnt to control data storage perms.

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Permissions that applications may use (names are subject to change):
 | Phone | Make Phone calls, either directly or through system voice call UI. |
 | Pictures | Access to Pictures directory and thumbnails. |
 | PublicDir | Access to Public directory. |
+| RemovableMedia | Use memory cards and USB sticks. |
 | Sharing | Use of sharing pages in the application to share data via Bluetooth, email or other accounts. |
 | Synchronization | Access to synchronization framework. |
 | UserDirs | Access to Documents, Downloads, Music, Pictures, Public and Video directories. |
@@ -127,7 +128,6 @@ Internal permissions that applications generally should not use directly:
 | Base       | Base set of permissions that every application is granted implicitly. |
 | CaptivePortal |
 | Connman |
-| DataStorages |
 | GnuPG |
 | FingerprintSensor |
 | Microphone |

--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ Internal permissions that applications generally should not use directly:
 | PinQuery |
 | Sensors |
 | Thumbnails |
-| UDisks |
+| UDisks | Permissions to call UDisks functions, includes UDisksListen. |
+| UDisksListen | Permissions to listen signals and property changes on UDisks2 interfaces. |
 
 ### Permission metadata format
 

--- a/permissions/Base.permission
+++ b/permissions/Base.permission
@@ -158,8 +158,8 @@ seccomp
 ### notifications
 include /etc/sailjail/permissions/Notifications.permission
 
-### udisks2
-include /etc/sailjail/permissions/UDisks.permission
+### Disable access to media by default
+disable-mnt
 
 ### privileged data
 # make sure privileged data directory exists

--- a/permissions/DataStorages.permission
+++ b/permissions/DataStorages.permission
@@ -1,7 +1,0 @@
-# -*- mode: sh -*-
-
-# x-sailjail-translation-catalog =
-# x-sailjail-translation-key-description =
-# x-sailjail-description = Removable media
-# x-sailjail-translation-key-long-description =
-# x-sailjail-long-description = Use memory cards and USB sticks

--- a/permissions/RemovableMedia.permission
+++ b/permissions/RemovableMedia.permission
@@ -1,0 +1,12 @@
+# -*- mode: sh -*-
+
+# x-sailjail-translation-catalog = sailjail-permissions
+# x-sailjail-translation-key-description = permission-la-removable_media
+# x-sailjail-description = Removable media
+# x-sailjail-translation-key-long-description = permission-la-removable_media_description
+# x-sailjail-long-description = Use memory cards and USB sticks
+
+### Allow to listen/talk to udisks2
+include /etc/sailjail/permissions/UDisksListen.permission
+
+ignore disable-mnt

--- a/permissions/UDisks.permission
+++ b/permissions/UDisks.permission
@@ -1,16 +1,19 @@
 # -*- mode: sh -*-
 
-# FIXME: what exactly requires udisks???
-
 # x-sailjail-translation-catalog =
-# x-sailjail-translation-key-description =
-# x-sailjail-description = Use UDisks2
-# x-sailjail-translation-key-long-description =
-# x-sailjail-long-description =
+# x-sailjail-translation-key-description = permission-la-udisks2
+# x-sailjail-description = Manage and access storage devices
+# x-sailjail-translation-key-long-description = permission-la-udisks2_description
+# x-sailjail-long-description = Permission to access the storage devices, allows to call device D-Bus methods.
 
-# BEG systembus-org.freedesktop.UDisks2.resource
-dbus-system.talk org.freedesktop.UDisks2
-dbus-system.broadcast org.freedesktop.UDisks2=org.freedesktop.UDisks2.*@/*
-dbus-system.talk org.freedesktop.UDisks2.*
-dbus-system.broadcast org.freedesktop.UDisks2.*=org.freedesktop.UDisks2.*@/*
-# END systembus-org.freedesktop.UDisks2.resource
+include /etc/sailjail/permissions/UDisksListen.permission
+
+# BEG systembus-org.freedesktop.UDisks2 method call access
+dbus-system.call org.freedesktop.UDisks2=org.freedesktop.DBus.Properties.Set@/*
+dbus-system.call org.freedesktop.UDisks2=org.freedesktop.UDisks2.Block.Format@/*
+dbus-system.call org.freedesktop.UDisks2=org.freedesktop.UDisks2.Block.Rescan@/*
+dbus-system.call org.freedesktop.UDisks2=org.freedesktop.UDisks2.Encrypted.Lock@/*
+dbus-system.call org.freedesktop.UDisks2=org.freedesktop.UDisks2.Encrypted.Unlock@/*
+dbus-system.call org.freedesktop.UDisks2=org.freedesktop.UDisks2.FileSystem.Mount@/*
+dbus-system.call org.freedesktop.UDisks2=org.freedesktop.UDisks2.FileSystem.Unmount@/*
+# END systembus-org.freedesktop.UDisks2 method call access

--- a/permissions/UDisksListen.permission
+++ b/permissions/UDisksListen.permission
@@ -1,0 +1,22 @@
+# -*- mode: sh -*-
+
+# x-sailjail-translation-catalog =
+# x-sailjail-translation-key-description = permission-la-udisks2_listen
+# x-sailjail-description = Access storage device information
+# x-sailjail-translation-key-long-description = permission-la-udisks2_description
+# x-sailjail-long-description = Permissions to access properties and to listen to property changes on storage devices
+
+# BEG systembus-org.freedesktop.UDisks2.resource
+dbus-system.broadcast org.freedesktop.UDisks2=org.freedesktop.UDisks2.*@/*
+dbus-system.broadcast org.freedesktop.UDisks2.*=org.freedesktop.UDisks2.*@/*
+
+# END systembus-org.freedesktop.UDisks2.resource
+# BEG systembus-org.freedesktop.UDisks2 call access
+### Allow to get available functions and access properties with getters
+dbus-system.call org.freedesktop.UDisks2=org.freedesktop.DBus.Introspectable.Introspect@/*
+dbus-system.call org.freedesktop.UDisks2=org.freedesktop.DBus.Properties.Get@/*
+dbus-system.call org.freedesktop.UDisks2=org.freedesktop.DBus.Properties.GetAll@/*
+### Not listed in udisks2defines.h but exists in the nemo-qml-plugin-systemsettings code and is thus required by many apps
+### TODO: remove when nemo-qml-plugin-systemsettings do not need this anymore
+dbus-system.call org.freedesktop.UDisks2=org.freedesktop.UDisks2.Manager.GetBlockDevices@/org/freedesktop/UDisks2/Manager
+# END systembus-org.freedesktop.UDisks2 call access


### PR DESCRIPTION
[permissions] Use disable-mnt to control data storage perms, move udisk2 include. OMP#JOLLA-49

Block access to any media mount with disable-mnt in Base.permissions.
Grant permissions to all media when DataStorages permission is used,
including UDisks2 D-Bus.

Move the UDisks permission include away from Base.permissions. This is
to be included separately or via DataStorages permission.