### PR TITLE
Add CommunicationHistory.permission.

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Permissions that applications may use (names are subject to change):
 | Calendar | Display and editing of calendar events. |
 | CallRecordings | Access recorded calls. |
 | Camera | Access to camera hardware to take photos or video. |
+| CommunicationHistory | Access call and message history. |
 | Contacts | Display and editing of contacts data. Access to contact cards. |
 | Documents | Access to Documents directory. |
 | Downloads | Access to Downloads directory. |

--- a/permissions/CommunicationHistory.permission
+++ b/permissions/CommunicationHistory.permission
@@ -1,0 +1,14 @@
+# -*- mode: sh -*-
+
+# x-sailjail-translation-catalog = sailjail-permissions
+# x-sailjail-translation-key-description = permission-la-calllogs
+# x-sailjail-description = Communication history
+# x-sailjail-translation-key-long-description = permission-la-calllogs_description
+# x-sailjail-long-description = View and edit previous calls and messages
+
+mkdir     ${HOME}/.local/share/commhistory
+whitelist ${HOME}/.local/share/commhistory
+
+dbus-user.talk org.nemomobile.CommHistory
+dbus-user.broadcast org.nemomobile.CommHistory=org.nemomobile.CommHistory.*@/org/nemomobile/CommHistory
+dbus-user.call org.nemomobile.CommHistory=org.nemomobile.CommHistory.*@/org/nemomobile/CommHistory

--- a/permissions/Messages.permission
+++ b/permissions/Messages.permission
@@ -6,33 +6,20 @@
 # x-sailjail-translation-key-long-description = permission-la-messages_description
 # x-sailjail-long-description = Display and send SMS and other types of messages
 
-# BEG systembus-org.ofono.resource
 dbus-system.talk org.ofono
 dbus-system.broadcast org.ofono=org.ofono.*@/*
-# END systembus-org.ofono.resource
 
-# BEG sessionbus-org.freedesktop.Telepathy.resource
 dbus-user.talk org.freedesktop.Telepathy
 dbus-user.broadcast org.freedesktop.Telepathy=org.freedesktop.Telepathy.*@/*
 dbus-user.talk org.freedesktop.Telepathy.*
 dbus-user.broadcast org.freedesktop.Telepathy.*=org.freedesktop.Telepathy.*@/*
-# END sessionbus-org.freedesktop.Telepathy.resource
 
-mkdir     ${HOME}/.local/share/commhistory
-whitelist ${HOME}/.local/share/commhistory
-
-# Temporary directory for outgoing MMS.
+# Temporary directory for outgoing MMS
 mkdir     ${HOME}/.cache/commhistory-tmp
 whitelist ${HOME}/.cache/commhistory-tmp
 
-# BEG sessionbus-org.nemomobile.CommHistory.resource
-dbus-user.talk org.nemomobile.CommHistory
-dbus-user.broadcast org.nemomobile.CommHistory=org.nemomobile.CommHistory.*@/*
-# END sessionbus-org.nemomobile.CommHistory.resource
-
-# BEG systembus-org.ofono.SmartMessagingAgent.resource
+# MMS
 dbus-system.talk org.ofono.SmartMessagingAgent
-# END systembus-org.ofono.SmartMessagingAgent.resource
 
 # Allow requesting sim pin
 include /etc/sailjail/permissions/PinQuery.permission

--- a/permissions/Phone.permission
+++ b/permissions/Phone.permission
@@ -6,40 +6,23 @@
 # x-sailjail-translation-key-long-description = permission-la-phone_description
 # x-sailjail-long-description = Make phone calls
 
-# BEG systembus-org.ofono.resource
+# Ofono to place calls etc.
 dbus-system.talk org.ofono
 dbus-system.broadcast org.ofono=org.ofono.*@/*
 dbus-system.broadcast org.ofono=org.nemomobile.ofono.*@/*
-# END systembus-org.ofono.resource
 
 # Voicecall service
 dbus-user.talk org.nemomobile.voicecall
 dbus-user.broadcast org.nemomobile.voicecall=org.nemomobile.voicecall.*@/*
-
-# BEG sessionbus-org.freedesktop.Telepathy.resource
 dbus-user.talk org.freedesktop.Telepathy
 dbus-user.broadcast org.freedesktop.Telepathy=org.freedesktop.Telepathy.*@/*
 dbus-user.talk org.freedesktop.Telepathy.*
 dbus-user.broadcast org.freedesktop.Telepathy.*=org.freedesktop.Telepathy.*@/*
-# END sessionbus-org.freedesktop.Telepathy.resource
 
-mkdir     ${HOME}/.local/share/commhistory
-whitelist ${HOME}/.local/share/commhistory
-
-# BEG sessionbus-org.nemomobile.CommHistory.resource
-dbus-user.talk org.nemomobile.CommHistory
-dbus-user.broadcast org.nemomobile.CommHistory=org.nemomobile.CommHistory.*@/*
-# END sessionbus-org.nemomobile.CommHistory.resource
-
-# BEG systembus-org.ofono.SmartMessagingAgent.resource
-dbus-system.talk org.ofono.SmartMessagingAgent
-# END systembus-org.ofono.SmartMessagingAgent.resource
-
-# BEG sessionbus-com.jolla.voicecall.ui.resource
+# Open Phone UI to make calls
 dbus-user.talk com.jolla.voicecall.ui
-# END sessionbus-com.jolla.voicecall.ui.resource
 
-# Have audio permissions implicitly.
+# Have audio permissions implicitly
 include /etc/sailjail/permissions/Audio.permission
 
 # Allow requesting sim pin

--- a/permissions/Phone.permission
+++ b/permissions/Phone.permission
@@ -27,7 +27,3 @@ include /etc/sailjail/permissions/Audio.permission
 
 # Allow requesting sim pin
 include /etc/sailjail/permissions/PinQuery.permission
-
-# BEG sessionbus-com.jolla.settings
-dbus-user.call com.jolla.settings=com.jolla.settings.ui.*@/*
-# END sessionbus-com.jolla.settings

--- a/permissions/jolla-messages.profile
+++ b/permissions/jolla-messages.profile
@@ -13,3 +13,5 @@
 dbus-user.own org.nemomobile.qmlmessages
 # FIXME: another systematic dbus-name to deal with?
 dbus-user.own org.freedesktop.Telepathy.Client.qmlmessages
+
+dbus-user.call com.jolla.settings=com.jolla.settings.ui.showPage@/com/jolla/settings/ui

--- a/permissions/voicecall-ui.profile
+++ b/permissions/voicecall-ui.profile
@@ -18,3 +18,5 @@ dbus-system.talk org.nemomobile.provisioning
 dbus-system.broadcast org.nemomobile.provisioning=org.nemomobile.provisioning.interface.*@/
 
 dbus-system.call com.nokia.dsme=com.nokia.dsme.request.*@/com/nokia/dsme/request
+
+dbus-user.call com.jolla.settings=com.jolla.settings.ui.showPage@/com/jolla/settings/ui

--- a/tools/dependencies.py
+++ b/tools/dependencies.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 #
 # Visualises permission dependencies
-# Copyright (c) Jolla Ltd. 2021
+# Copyright (c) 2021 Jolla Ltd.
+# Copyright (c) 2021 Open Mobile Platform LLC.
 #
 # You may use this file under the terms of the BSD license as follows:
 #
@@ -127,8 +128,8 @@ class Forest:
     def digraph(self):
         dot = graphviz.Digraph()
         for node in self.nodes.values():
-            dot.attr('node', style=node.style, fillcolor=node.color)
-            dot.node(node.name, node.text)
+            dot.node(node.name, node.text, style=node.style,
+                     fillcolor=node.color)
             for child in node.children:
                 dot.edge(node.name, child.name, arrowhead='vee')
         return dot


### PR DESCRIPTION
Remove CommHistory specific permissions from Phone and Messages and move
those to separate CommunicationHistory.permission file. Allow only relevant D-Bus
interfaces.

Remove those old resource comments and add more useful comments for the
purposes of the rules.

Move settings permission outside Phone and Messages permission as
it doesn't belong here as it's about being able to open a Settings
page which is an application specific thing to do.