### PR TITLE
Use whitelisting for ${RUNUSER}

### DIFF
--- a/permissions/Accounts.permission
+++ b/permissions/Accounts.permission
@@ -11,6 +11,12 @@ whitelist /usr/share/xml/accounts
 whitelist /usr/share/accounts
 whitelist /usr/share/libsailfishkeyprovider/storedkeys.ini
 
+# To create accounts using libsignon
+whitelist ${RUNUSER}/signond
+read-only ${RUNUSER}/signond
+# Application must be able to create a socket here
+whitelist ${RUNUSER}/signonui
+
 mkdir     ${PRIVILEGED}/Accounts
 privileged-data Accounts
 

--- a/permissions/Audio.permission
+++ b/permissions/Audio.permission
@@ -8,6 +8,9 @@
 
 private-etc pulse
 
+whitelist ${RUNUSER}/pulse
+read-only ${RUNUSER}/pulse
+
 mkdir     ${HOME}/.config/pulse
 whitelist ${HOME}/.config/pulse
 

--- a/permissions/Base.permission
+++ b/permissions/Base.permission
@@ -30,10 +30,6 @@ include disable-passwdmgr.inc
 # include disable-programs.inc
 # include disable-xdg.inc
 
-# Runuser blacklisting
-mkdir     ${RUNUSER}/messageserver
-blacklist ${RUNUSER}/messageserver
-
 ### home directory whitelisting
 whitelist ${HOME}/.cursors/default
 whitelist ${HOME}/.local/share/glib-2.0/schemas
@@ -136,6 +132,7 @@ dbus-user.broadcast com.nokia.time=com.nokia.time.*@/*
 # BEG sessionbus-org.maliit.server.resource
 dbus-user.talk org.maliit.server
 dbus-user.broadcast org.maliit.server=org.maliit.server.*@/*
+whitelist ${RUNUSER}/maliit-server
 read-only ${RUNUSER}/maliit-server
 # END sessionbus-org.maliit.server.resource
 

--- a/permissions/Email.permission
+++ b/permissions/Email.permission
@@ -7,8 +7,9 @@
 # x-sailjail-long-description = Read and send email
 
 # MessageServer socket
-noblacklist ${RUNUSER}/messageserver
-read-only   ${RUNUSER}/messageserver
+mkdir     ${RUNUSER}/messageserver
+whitelist ${RUNUSER}/messageserver
+read-only ${RUNUSER}/messageserver
 
 # Messaging framework
 mkdir     ${HOME}/.qmf


### PR DESCRIPTION
Instead of using blacklists, use whitelist for ${RUNUSER}. This allows
better control over what application can see in that directory.

Needs [libsignon!11](https://git.sailfishos.org/mer-core/libsignon/merge_requests/11).