### PR TITLE
Move pin query to its own permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Internal permissions that applications generally should not use directly:
 | FingerprintSensor |
 | Microphone |
 | Notifications |
+| PinQuery |
 | Sensors |
 | Thumbnails |
 | UDisks |

--- a/permissions/Messages.permission
+++ b/permissions/Messages.permission
@@ -35,5 +35,4 @@ dbus-system.talk org.ofono.SmartMessagingAgent
 # END systembus-org.ofono.SmartMessagingAgent.resource
 
 # Allow requesting sim pin
-dbus-user.talk com.jolla.PinQuery
-dbus-user.broadcast com.jolla.PinQuery=com.jolla.PinQuery.*@/*
+include /etc/sailjail/permissions/PinQuery.permission

--- a/permissions/Phone.permission
+++ b/permissions/Phone.permission
@@ -43,8 +43,7 @@ dbus-user.talk com.jolla.voicecall.ui
 include /etc/sailjail/permissions/Audio.permission
 
 # Allow requesting sim pin
-dbus-user.talk com.jolla.PinQuery
-dbus-user.broadcast com.jolla.PinQuery=com.jolla.PinQuery.*@/*
+include /etc/sailjail/permissions/PinQuery.permission
 
 # BEG sessionbus-com.jolla.settings
 dbus-user.call com.jolla.settings=com.jolla.settings.ui.*@/*

--- a/permissions/PinQuery.permission
+++ b/permissions/PinQuery.permission
@@ -1,0 +1,5 @@
+# Privileged D-Bus API
+# Allows to open pin query dialog
+dbus-user.talk com.jolla.PinQuery
+dbus-user.call com.jolla.PinQuery=com.jolla.PinQuery.requestSimPin@/com/jolla/PinQuery
+dbus-user.broadcast com.jolla.PinQuery=com.jolla.PinQuery.requestCanceled@/com/jolla/PinQuery


### PR DESCRIPTION
Move pin query dialog opening to its own permission but include that
from Phone and Messages. Also restrict this to pin query only as that
service name exposes some other interfaces as well.

Add a comment that this D-Bus API requires privileged access to
function. This permission is internal without any descriptions. As this
is only used through Phone and Messages those are not needed.