### PR TITLE
Restrict audio permissions, update Microphone perms.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Permissions that applications may use (names are subject to change):
 | Ambience   | Set and edit ambiences. |
 | AppLaunch  | Launching and stopping systemd services. This is usually needed for background tasks. |
 | ApplicationInstallation | Installing and uninstalling applications. |
-| Audio | Playing audio, changing audio configuration and showing audio controls on lockscreen. |
+| Audio | Playing and recording audio (since Pulseaudio streams cannot be separated both are enabled with this, but it is subject to change), changing audio configuration and showing audio controls on lockscreen. |
 | Bluetooth | Connecting to and using Bluetooth and NFC hardware. |
 | Calendar | Display and editing of calendar events. |
 | CallRecordings | Access recorded calls. |
@@ -112,7 +112,7 @@ Permissions that applications may use (names are subject to change):
 | Location | Use GPS and positioning. |
 | MediaIndexing | Access to Tracker to list files on device. If you have access to a data directory, you may want to use also this. |
 | Messages | Access to message data and to send SMS messages. |
-| WebView | If you use Gecko based WebView you need this. |
+| Microphone | Record audio with microphone. Use Audio permission for playback of the recorded audio (but since Pulseaudio streams cannot be separated this enables also audio playback, which is subject to change). |
 | Music | Access to Music directory, playlists and coverart cache. |
 | Phone | Make Phone calls, either directly or through system voice call UI. |
 | Pictures | Access to Pictures directory and thumbnails. |
@@ -122,6 +122,7 @@ Permissions that applications may use (names are subject to change):
 | Synchronization | Access to synchronization framework. |
 | UserDirs | Access to Documents, Downloads, Music, Pictures, Public and Video directories. |
 | Videos | Access to Videos directory and thumbnails. |
+| WebView | If you use Gecko based WebView you need this. |
 
 Internal permissions that applications generally should not use directly:
 | Permission | Description |
@@ -131,7 +132,6 @@ Internal permissions that applications generally should not use directly:
 | Connman |
 | GnuPG |
 | FingerprintSensor |
-| Microphone |
 | Notifications |
 | PinQuery |
 | Sensors |

--- a/permissions/Audio.permission
+++ b/permissions/Audio.permission
@@ -2,9 +2,16 @@
 
 # x-sailjail-translation-catalog = sailjail-permissions
 # x-sailjail-translation-key-description = permission-la-audio
-# x-sailjail-description = Play audio
+# x-sailjail-description = Play and record audio
 # x-sailjail-translation-key-long-description = permission-la-audio_description
-# x-sailjail-long-description = Play audio and show audio controls on lockscreen
+# x-sailjail-long-description = Play and record audio, and show audio controls on lockscreen
+
+### Do not prevent access to Pulseaudio socket etc. audio devices
+# FIXME: Separete permissions as this gives access to Pulseaudio, Alsa and to microphone.
+# In order to support recording with microphone use the Microphone permission
+# separately as this functionality is subject to change when Pulseaudio streams
+# can be isolated with permissions.
+ignore nosound
 
 private-etc pulse
 

--- a/permissions/Base.permission
+++ b/permissions/Base.permission
@@ -170,6 +170,10 @@ privileged-data -
 whitelist ${HOME}/.config/QtProject/qtlogging.ini
 read-only ${HOME}/.config/QtProject/qtlogging.ini
 
+### Block direct access to sound devices and configs
+# Disables access to pulseaudio by default
+nosound
+
 ### Disable access to well-known directories (XDG user directories) by default
 # These rules say that there is an empty read-only directory inside
 # sandbox. They are prevented separately for each directory with

--- a/permissions/Microphone.permission
+++ b/permissions/Microphone.permission
@@ -1,7 +1,10 @@
 # -*- mode: sh -*-
 
-# x-sailjail-translation-catalog =
-# x-sailjail-translation-key-description =
-# x-sailjail-description = Microphone
-# x-sailjail-translation-key-long-description =
-# x-sailjail-long-description =
+# x-sailjail-translation-catalog = sailjail-catalog
+# x-sailjail-translation-key-description = permission-la-microphone
+# x-sailjail-description = Access microphone
+# x-sailjail-translation-key-long-description = permission-la-microphone_description
+# x-sailjail-long-description = Record audio with microphone
+
+# TODO: playback and record streams cannot be separated on pulseaudio, remove this when they are.
+include /etc/sailjail/permissions/Audio.permission


### PR DESCRIPTION
Add use of `nosound` to block access to any audio device, including Pulseaudio. Remove this with Audio permissions.

Add mere translations for Microphone permissions as there are no means to separate playback and recording as of now. Microphone can be used as a separate permission, which as of now allows also playback of audio since `Audio` permission is included.