### PR TITLE
Ensure sailfish-browser can add desktop icons

### DIFF
--- a/permissions/sailfish-browser.profile
+++ b/permissions/sailfish-browser.profile
@@ -24,3 +24,5 @@ whitelist ${HOME}/.mozilla/captiveportal
 # Saving bookmarks to launcher feature
 # Override read-only from whitelist-common.inc
 read-write ${HOME}/.local/share/applications
+# Stop Base.permission from making the dir read-only
+ignore read-only ${HOME}/.local/share/applications


### PR DESCRIPTION
Fixes a regression introduced in 8125bba05f1352 which gave Base.permissions priority.

This change ensures sailfish-browser's ability to read/write to~/.local/share/applications isn't overridden by Base.permissions later.

I just followed the advice given in the bug report by @spiiroin and it works nicely, tested using the new [pop-up menu PR](https://github.com/sailfishos/sailfish-browser/pull/808).