### PR TITLE
Abstract Telepathy access for messages.

### DIFF
--- a/permissions/Messages.permission
+++ b/permissions/Messages.permission
@@ -14,6 +14,9 @@ dbus-user.broadcast org.freedesktop.Telepathy=org.freedesktop.Telepathy.*@/*
 dbus-user.talk org.freedesktop.Telepathy.*
 dbus-user.broadcast org.freedesktop.Telepathy.*=org.freedesktop.Telepathy.*@/*
 
+# Application specific Telepathy client D-Bus path
+dbus-user.own org.freedesktop.Telepathy.Client.${OrganizationName}.${ApplicationName}
+
 # Temporary directory for outgoing MMS
 mkdir     ${HOME}/.cache/commhistory-tmp
 whitelist ${HOME}/.cache/commhistory-tmp

--- a/permissions/jolla-messages.profile
+++ b/permissions/jolla-messages.profile
@@ -11,7 +11,5 @@
 ### APPLICATION
 # FIXME: This is a legacy D-Bus service name, we need to drop it at some point
 dbus-user.own org.nemomobile.qmlmessages
-# FIXME: another systematic dbus-name to deal with?
-dbus-user.own org.freedesktop.Telepathy.Client.qmlmessages
 
 dbus-user.call com.jolla.settings=com.jolla.settings.ui.showPage@/com/jolla/settings/ui


### PR DESCRIPTION
Abstract the Telepathy access for messages by using organization and
application names in the D-Bus name ownership. These are supported via
--template in sailjail that will get the org and app names passed and
processed by firejail.