### PR TITLE
[permissions] Add access to tracker miner data to MediaIndexing. OMP#JOLLA-144 JB#54283

### DIFF
--- a/permissions/MediaIndexing.permission
+++ b/permissions/MediaIndexing.permission
@@ -8,6 +8,8 @@
 
 whitelist /usr/share/tracker
 whitelist /usr/share/tracker3
+whitelist /usr/share/tracker-miners
+whitelist /usr/share/tracker3-miners
 
 mkdir     ${HOME}/.cache/tracker
 whitelist ${HOME}/.cache/tracker


### PR DESCRIPTION
This allows tracker-extract to run within a sandbox.