### PR TITLE
Move privileged Images dir access to Pictures

### DIFF
--- a/permissions/Pictures.permission
+++ b/permissions/Pictures.permission
@@ -13,4 +13,7 @@ whitelist   ${HOME}/Pictures
 whitelist ${HOME}/android_storage/Pictures
 whitelist ${HOME}/android_storage/DCIM
 
+mkdir     ${PRIVILEGED}/Images
+privileged-data Images
+
 include /etc/sailjail/permissions/Thumbnails.permission

--- a/permissions/jolla-gallery.profile
+++ b/permissions/jolla-gallery.profile
@@ -1,6 +1,0 @@
-# -*- mode: sh -*-
-
-# Firejail profile for /usr/bin/jolla-gallery
-
-mkdir     ${PRIVILEGED}/Images
-privileged-data Images


### PR DESCRIPTION
Provide access to the cloud/social media images that are on the device
via Pictures permission. Remove the jolla-gallery.profile as unnecessary
(empty as of now).