### PR TITLE
Add booster profile files

### DIFF
--- a/permissions/Base.permission
+++ b/permissions/Base.permission
@@ -136,6 +136,10 @@ whitelist ${RUNUSER}/maliit-server
 read-only ${RUNUSER}/maliit-server
 # END sessionbus-org.maliit.server.resource
 
+# Protect booster socket directory
+whitelist ${RUNUSER}/mapplauncherd
+read-only ${RUNUSER}/mapplauncherd
+
 ### network
 protocol unix
 net none

--- a/permissions/booster-browser.profile
+++ b/permissions/booster-browser.profile
@@ -1,0 +1,3 @@
+# -*- mode: sh -*-
+whitelist /usr/share/booster-browser
+include /etc/sailjail/permissions/booster.profile

--- a/permissions/booster-generic.profile
+++ b/permissions/booster-generic.profile
@@ -1,0 +1,2 @@
+# -*- mode: sh -*-
+include /etc/sailjail/permissions/booster.profile

--- a/permissions/booster-qt5.profile
+++ b/permissions/booster-qt5.profile
@@ -1,0 +1,2 @@
+# -*- mode: sh -*-
+include /etc/sailjail/permissions/booster.profile

--- a/permissions/booster-silica-media.profile
+++ b/permissions/booster-silica-media.profile
@@ -1,0 +1,3 @@
+# -*- mode: sh -*-
+whitelist /usr/share/booster-silica-media
+include /etc/sailjail/permissions/booster.profile

--- a/permissions/booster-silica-qt5.profile
+++ b/permissions/booster-silica-qt5.profile
@@ -1,0 +1,3 @@
+# -*- mode: sh -*-
+whitelist /usr/share/booster-silica-qt5
+include /etc/sailjail/permissions/booster.profile

--- a/permissions/booster-silica-session.profile
+++ b/permissions/booster-silica-session.profile
@@ -1,0 +1,2 @@
+# -*- mode: sh -*-
+include /etc/sailjail/permissions/booster.profile

--- a/permissions/booster.profile
+++ b/permissions/booster.profile
@@ -1,0 +1,25 @@
+# -*- mode: sh -*-
+
+# Single-instance booster feature needs to be
+# able to execute a helper binary.
+private-bin single-instance
+
+# Provide read-access to legacy privileges config
+whitelist /usr/share/mapplauncherd/privileges
+whitelist /usr/share/mapplauncherd/privileges.d
+
+# Some boosters are executed as systemd units
+# and need to have access to systemd socket for
+# sending startup notifications.
+noblacklist ${RUNUSER}/systemd
+read-only   ${RUNUSER}/systemd
+
+# Boosters needs to be able to create sockets.
+# Override read-only from Base.permission.
+ignore read-only ${RUNUSER}/mapplauncherd
+
+# Boosters need to be able to prompt user for launch
+# permission and query application information.
+# Allow ipc with sailjail daemon.
+dbus-system.talk org.sailfishos.sailjaild1
+dbus-system.call org.sailfishos.sailjaild1=org.sailfishos.sailjaild1.*@/*


### PR DESCRIPTION
Boosting sandboxed applications works by launching booster in sandbox.
Such application boosters use permissions for the the application they
are handling. Any additional sandboxing tweaks that are needed are
handled by use of booster type specific profile files.

Signed-off-by: Simo Piiroinen <simo.piiroinen@jolla.com>