### PR TITLE
Add default profile configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ For Exec line use **sailjail** to start the application, pass the file name of t
 and refer to the application binary with the full path.
 
 To declare permissions and data directories you need to add **X-Sailjail** section to the
-desktop file. Under the **X-Sailjail** section add
+desktop file. This is called _an application profile_. Under the **X-Sailjail** section add
 
 | Keyword | Description |
 | :---    | :---        |
@@ -87,6 +87,25 @@ data needs to be accessible by other applications.
 If application doesn't have a permission for a directory, all data in that directory will be hidden
 and the application sees only an empty read-only directory in that path. This allows to regular file
 access checks to function in expected way.
+
+## Sandboxing of applications without application profile
+
+If application does not define application profile, i.e. **X-Sailjail** section in its desktop file,
+a default profile may be applied. This is defined by configuration (see
+_config/50-default-profile.conf_) and applies a relaxed set of permissions which should be
+compatible with most existing and well-behaving applications. It specifically does not grant access
+to any sensitive data normally protected by _privileged_ group.
+
+Some assumptions about the application are made:
+- The application has only one binary as specified by _Exec_ key in desktop file
+- The application installs its own files in _/usr/share/<app binary name>_
+- The application stores its own private data in _~/.local/share/<app binary name>_
+- The application stores its config data in _~/.config/<app binary name>_
+- The application stores its cached data in _~/.cache/<app binary name>_
+- The application stores common data in user directories as specified by UserDirs or on memory card
+- The application doesn't need access to other application's data outside those common directories
+- The application doesn't need access to privileged data
+- The application doesn't need access to privileged or otherwise private D-Bus APIs
 
 ## Permissions
 

--- a/config/50-default-profile.conf
+++ b/config/50-default-profile.conf
@@ -1,0 +1,2 @@
+[Default Profile]
+Permissions=Audio;Bluetooth;Camera;Internet;Location;MediaIndexing;Microphone;NFC;RemovableMedia;UserDirs;WebView

--- a/rpm/sailjail-permissions.spec
+++ b/rpm/sailjail-permissions.spec
@@ -11,6 +11,7 @@ BuildRequires: qt5-qttools-linguist
 BuildRequires: python3-base
 
 %define permissions_dir %{_sysconfdir}/sailjail/permissions
+%define config_dir %{_sysconfdir}/sailjail/config
 
 %description
 %{summary}.
@@ -30,6 +31,8 @@ make %{?_smp_mflags}
 %license COPYING
 %dir %attr(755,root,root) %{permissions_dir}
 %{permissions_dir}/*
+%dir %attr(755,root,root) %{config_dir}
+%{config_dir}/*
 %{_datadir}/translations/*.qm
 
 %package ts-devel

--- a/sailjail-permissions.pro
+++ b/sailjail-permissions.pro
@@ -3,6 +3,7 @@ TEMPLATE = subdirs
 SUBDIRS += translations
 
 DISTFILES = \
+    config/*.conf \
     permissions/*.permission \
     permissions/*.profile \
     rpm/sailjail-permissions.spec \
@@ -10,9 +11,13 @@ DISTFILES = \
     README.md \
     COPYING
 
+config.files = \
+    config/*.conf
+config.path = /etc/sailjail/config
+
 permissions.files = \
     permissions/*.permission \
     permissions/*.profile
 permissions.path = /etc/sailjail/permissions
 
-INSTALLS += permissions
+INSTALLS += config permissions


### PR DESCRIPTION
Default profile defines the set of permissions that is applied when
application doesn't define any application profile for sandboxing. It
allows sandboxing of applications antedating sandboxing.

See also: https://github.com/sailfishos/sailjail/pull/50