### PR TITLE
[permissions] Add permission for /home/.shared directory. JB#54619 OMP#OS-7158

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Permissions that applications may use (names are subject to change):
 | Pictures | Access to Pictures directory and thumbnails. |
 | PublicDir | Access to Public directory. |
 | RemovableMedia | Use memory cards and USB sticks. |
+| SharedStorage | Access application's storage shared between users. |
 | Sharing | Use of sharing pages in the application to share data via Bluetooth, email or other accounts. |
 | Synchronization | Access to synchronization framework. |
 | UserDirs | Access to Documents, Downloads, Music, Pictures, Public and Video directories. |

--- a/permissions/SharedStorage.permission
+++ b/permissions/SharedStorage.permission
@@ -1,0 +1,10 @@
+# -*- mode: sh -*-
+
+# x-sailjail-translation-catalog = sailjail-permissions
+# x-sailjail-translation-key-description = permission-la-sharedstorage
+# x-sailjail-description = Shared storage
+# x-sailjail-translation-key-long-description = permission-la-sharedstorage_description
+# x-sailjail-long-description = Access application's storage shared between users
+
+mkdir       /home/.shared/${OrganizationName}/${ApplicationName}
+whitelist   /home/.shared/${OrganizationName}/${ApplicationName}


### PR DESCRIPTION
Contributes to https://github.com/sailfishos/firejail/pull/13.
Some applications like an antivirus and etc want to get access to some shared directory between all users to store big blobs of data in it, /home/.shared is good one.
Permission SharedStorage will make directory inside by /OrganizationName/ApplicationName.