### PR TITLE
[permissions] Add /etc/kcapi folder to the Base perms. Fixes JB#54719

### DIFF
--- a/permissions/Base.permission
+++ b/permissions/Base.permission
@@ -67,6 +67,7 @@ private-etc os-release
 private-etc localtime
 private-etc mtab
 private-etc mime.types
+private-etc kcapi
 
 ### D-Bus
 # BEG systembus-filter.resource


### PR DESCRIPTION
There is need to add /etc/kcapi folder to the Base.permission to allow applications to use additional crypto functionality.