### PR TITLE
[permissions] Create maliit-server socket directory. Contributes to JB#54741

### DIFF
--- a/permissions/Base.permission
+++ b/permissions/Base.permission
@@ -133,6 +133,7 @@ dbus-user.broadcast com.nokia.time=com.nokia.time.*@/*
 # BEG sessionbus-org.maliit.server.resource
 dbus-user.talk org.maliit.server
 dbus-user.broadcast org.maliit.server=org.maliit.server.*@/*
+mkdir ${RUNUSER}/maliit-server
 whitelist ${RUNUSER}/maliit-server
 read-only ${RUNUSER}/maliit-server
 # END sessionbus-org.maliit.server.resource


### PR DESCRIPTION
Ensure the maliit-server socket directory exists prior to creating the
sandbox, to ensure that the directory will be mounted.

Otherwise, if the maliit-server is started after some other sandboxed
service or application, the original sandboxed service or application
will never get the maliit-server socket directory mounted for them.