### PR TITLE
Add profile for voicecall-ui-prestart.

### DIFF
--- a/permissions/voicecall-ui.profile
+++ b/permissions/voicecall-ui.profile
@@ -1,18 +1,6 @@
 # -*- mode: sh -*-
-
-# Firejail profile for /usr/bin/jolla-messages
-
-# x-sailjail-translation-catalog =
-# x-sailjail-translation-key-description =
-# x-sailjail-description = Execute voicecall-ui application
-# x-sailjail-translation-key-long-description =
-# x-sailjail-long-description =
-
-### APPLICATION
 dbus-user.own com.jolla.voicecall.ui
 dbus-user.own com.nokia.telephony.callhistory
-# FIXME: A legacy directory that should be renamed
-whitelist /usr/share/voicecall-ui-jolla
 
 dbus-system.talk org.nemomobile.provisioning
 dbus-system.broadcast org.nemomobile.provisioning=org.nemomobile.provisioning.interface.*@/

--- a/rpm/sailjail-permissions.spec
+++ b/rpm/sailjail-permissions.spec
@@ -26,6 +26,8 @@ make %{?_smp_mflags}
 %install
 %qmake5_install
 
+ln -s voicecall-ui.profile %{buildroot}%{permissions_dir}/voicecall-ui-prestart.profile
+
 %files
 %defattr(-,root,root,-)
 %license COPYING


### PR DESCRIPTION
Add profile for voicecall-ui-prestart because it has different name from
the binary name. As it is the same application as voicecall-ui, use a
symbolic link.

Also remove extra stuff from voicecall-ui. Now that data directory is
set properly, we can also remove that FIXME and the whitelist line.