### PR TITLE
[permission] Add Microphone permission to the Camera. Fixes JB#55078

### DIFF
--- a/permissions/Camera.permission
+++ b/permissions/Camera.permission
@@ -8,6 +8,7 @@
 # This is about access to device's camera hardware, not data
 
 include /etc/sailjail/permissions/Sensors.permission
+include /etc/sailjail/permissions/Microphone.permission
 
 # BEG systembus-org.maemo.resource.manager
 dbus-system.talk org.maemo.resource.manager


### PR DESCRIPTION
Audio permission is needed in order to get microphone access.