### PR TITLE
[sailjail-permissions] Remove tracker1 content from MediaIndexing. JB#55207

### DIFF
--- a/permissions/MediaIndexing.permission
+++ b/permissions/MediaIndexing.permission
@@ -6,23 +6,8 @@
 # x-sailjail-translation-key-long-description = permission-la-media_indexing_description
 # x-sailjail-long-description = List files stored on device
 
-whitelist /usr/share/tracker
 whitelist /usr/share/tracker3
-whitelist /usr/share/tracker-miners
 whitelist /usr/share/tracker3-miners
-
-mkdir     ${HOME}/.cache/tracker
-whitelist ${HOME}/.cache/tracker
-
-mkdir     ${HOME}/.local/share/tracker/data
-whitelist ${HOME}/.local/share/tracker/data
-
-# BEG sessionbus-org.freedesktop.Tracker1.resource
-dbus-user.talk org.freedesktop.Tracker1
-dbus-user.broadcast org.freedesktop.Tracker1=org.freedesktop.Tracker1.*@/*
-dbus-user.talk org.freedesktop.Tracker1.*
-dbus-user.broadcast org.freedesktop.Tracker1.*=org.freedesktop.Tracker1.*@/*
-# END sessionbus-org.freedesktop.Tracker1.resource
 
 dbus-user.talk org.freedesktop.Tracker3.Miner.Files
 dbus-user.broadcast org.freedesktop.Tracker3.Miner.Files=org.freedesktop.Tracker3.*@/*


### PR DESCRIPTION
Shouldn't be needed, though not much harm either. Mostly was getting
confused why I was getting back the directories even though trying
to delete them to save space.

@rainemak @Tomin1 @adenexter 