### PR TITLE
[sailjail-permissions] Add support for gecko-camera. JB#55053

### DIFF
--- a/permissions/WebView.permission
+++ b/permissions/WebView.permission
@@ -29,6 +29,9 @@ dbus-user.talk org.nemo.transferengine
 dbus-user.broadcast org.nemo.transferengine=org.nemo.transferengine.*@/*
 # END sessionbus-org.nemo.transferengine.resource
 
+# gecko-camera
+whitelist /usr/lib/gecko-camera/plugins
+
 ### INDIRECT/UNKNOWN
 
 # some side effect from some xdg action ?

--- a/permissions/sailfish-browser.profile
+++ b/permissions/sailfish-browser.profile
@@ -17,3 +17,6 @@ dbus-user.call com.jolla.settings=com.jolla.settings.ui.showTransfers@/com/jolla
 read-write ${HOME}/.local/share/applications
 # Stop Base.permission from making the dir read-only
 ignore read-only ${HOME}/.local/share/applications
+
+# gecko-camera
+whitelist /usr/lib/gecko-camera/plugins


### PR DESCRIPTION
Browser and webview use gecko-camera to access the video camera for
WebRTC communication. gecko-camera is a plugin-based library and needs
access to the plugins directory.