### PR TITLE
[sailjail-permissions] Revert "Add support for gecko-camera. JB#55053"

### DIFF
--- a/permissions/WebView.permission
+++ b/permissions/WebView.permission
@@ -29,9 +29,6 @@ dbus-user.talk org.nemo.transferengine
 dbus-user.broadcast org.nemo.transferengine=org.nemo.transferengine.*@/*
 # END sessionbus-org.nemo.transferengine.resource
 
-# gecko-camera
-whitelist /usr/lib/gecko-camera/plugins
-
 ### INDIRECT/UNKNOWN
 
 # some side effect from some xdg action ?

--- a/permissions/sailfish-browser.profile
+++ b/permissions/sailfish-browser.profile
@@ -17,6 +17,3 @@ dbus-user.call com.jolla.settings=com.jolla.settings.ui.showTransfers@/com/jolla
 read-write ${HOME}/.local/share/applications
 # Stop Base.permission from making the dir read-only
 ignore read-only ${HOME}/.local/share/applications
-
-# gecko-camera
-whitelist /usr/lib/gecko-camera/plugins


### PR DESCRIPTION
This reverts commit 2c0dd6a82dda827386a382c980b6f91f2c7d7dd3.

There is no need for additional configuration, because applications
already have acess to the lib directory and its descendants.