### PR TITLE
[permissions] Fix libsignond bus permission. JB#55409

### DIFF
--- a/permissions/Accounts.permission
+++ b/permissions/Accounts.permission
@@ -12,9 +12,11 @@ whitelist /usr/share/accounts
 whitelist /usr/share/libsailfishkeyprovider/storedkeys.ini
 
 # To create accounts using libsignon
+mkdir ${RUNUSER}/signond
 whitelist ${RUNUSER}/signond
 read-only ${RUNUSER}/signond
 # Application must be able to create a socket here
+mkdir ${RUNUSER}/signonui
 whitelist ${RUNUSER}/signonui
 
 mkdir     ${PRIVILEGED}/Accounts


### PR DESCRIPTION
com.google.code.AccountsSSO.SingleSignOn is located on system bus.
Fixes error: `SignOn::ConnectionManager::init:130 - Unable to activate p2p signond service!` when attempting to create email-account.