### PR TITLE
media: Give access to /etc/gst-droid to media and camera applications

### DIFF
--- a/permissions/Base.permission
+++ b/permissions/Base.permission
@@ -72,6 +72,9 @@ private-etc localtime
 private-etc mtab
 private-etc mime.types
 private-etc kcapi
+# Codec config
+private-etc gst-droid
+
 
 ### D-Bus
 # BEG systembus-filter.resource


### PR DESCRIPTION
[media] Give access to /etc/gst-droid to media and camera applications. Fixes JB#55372

Config there enables optional codecs such as h265, and specifies camera quirks on some devices.