### PR TITLE
[permissions] Add MmsHandler to Messages.permission. Fixes JB#55052

### DIFF
--- a/permissions/Messages.permission
+++ b/permissions/Messages.permission
@@ -23,6 +23,8 @@ whitelist ${HOME}/.cache/commhistory-tmp
 
 # MMS
 dbus-system.talk org.ofono.SmartMessagingAgent
+dbus-system.talk org.nemomobile.MmsHandler
+dbus-system.broadcast org.nemomobile.MmsHandler=org.nemomobile.MmsHandler.*@/*
 
 # Roaming checking
 dbus-user.talk com.jolla.Connectiond


### PR DESCRIPTION
Messages app used to get this through Sharing.permission until it was
removed in 659c9354cb7ad33bd032de035a7993c503049ff8. That was of course
wrong but it made MMS sending work. Add rules to access MmsHandler to
Messages.permission to fix MMS sending.