### PR TITLE
[sailjail-permissions] Add a permission to talk over secrets daemon DBus. Contributes to JB#56300

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Internal permissions that applications generally should not use directly:
 | FingerprintSensor |
 | Notifications |
 | PinQuery |
+| Secrets |
 | Sensors |
 | Sharing |
 | Thumbnails |

--- a/permissions/GnuPG.permission
+++ b/permissions/GnuPG.permission
@@ -13,3 +13,8 @@ noblacklist ${HOME}/.gnupg
 private-bin gpg2
 private-bin gpg-agent
 private-bin pinentry
+
+# pinentry is talking to the Secrets daemon in pipe mode
+# this include can be safely removed when the gpg-agent will
+# run in daemon mode.
+include /etc/sailjail/permissions/Secrets.permission

--- a/permissions/Secrets.permission
+++ b/permissions/Secrets.permission
@@ -1,0 +1,16 @@
+# -*- mode: sh -*-
+
+# x-sailjail-translation-catalog =
+# x-sailjail-translation-key-description =
+# x-sailjail-description = Secrets
+# x-sailjail-translation-key-long-description =
+# x-sailjail-long-description = Use DBus API to access the Sailfish Secrets daemon
+
+mkdir     ${RUNUSER}/sailfishsecretsd
+whitelist ${RUNUSER}/sailfishsecretsd
+read-only ${RUNUSER}/sailfishsecretsd
+
+# Allow discovery of the p2p address used by the daemon.
+dbus-user.talk      org.sailfishos.secrets.daemon.discovery
+dbus-user.call      org.sailfishos.secrets.daemon.discovery=org.sailfishos.secrets.daemon.discovery.peerToPeerAddress@/Sailfish/Secrets/Discovery
+


### PR DESCRIPTION
…Bus.

Allow GnuPG pinentry to talk to the secrets daemon also.

This requires sailfishos/sailfish-secrets#178 to be merged.
Without these two PRs, the email signature in email application is failing.

@chriadam and @pvuorela, I've no real idea if the dbus-user entries I've put here make sense or not. If you may review or ask anyone else to review, that would be great. Thank you.