### PR TITLE
[permissions] Add location.conf file directory to whitelist. Contributes to JB#56083

### DIFF
--- a/permissions/Location.permission
+++ b/permissions/Location.permission
@@ -7,6 +7,7 @@
 # x-sailjail-long-description = Use high and low accuracy positioning
 
 whitelist /usr/share/GConf/gsettings/geoclue
+whitelist /var/lib/location
 
 private-etc location
 


### PR DESCRIPTION
In package `nemo-qml-plugin-systemsettings` `location.conf` has been moved to `/var/lib/location` directory for sandboxing support.

This change adds this directory to the whitelist for applications that need `Location` permission.