### PR TITLE
[permissions] Add contextkit dir to base permissions. JB#56324

### DIFF
--- a/permissions/Base.permission
+++ b/permissions/Base.permission
@@ -50,6 +50,7 @@ whitelist /usr/share/translations
 whitelist /usr/share/zoneinfo
 whitelist /usr/share/glib-2.0
 whitelist /usr/share/mime
+whitelist /usr/share/contextkit
 
 include whitelist-usr-share-common.inc
 


### PR DESCRIPTION
Data provider qml files, needed by the qml module, installed there.

@Tomin1 @spiiroin 