### PR TITLE
Add Compatibility permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Internal permissions that applications generally should not use directly:
 | :---       | :---        |
 | Base       | Base set of permissions that every application is granted implicitly. |
 | CaptivePortal |
+| Compatibility | Access to binaries for compatibility. Direct use of binaries should be avoided. |
 | Connman |
 | GnuPG |
 | FingerprintSensor |

--- a/config/50-default-profile.conf
+++ b/config/50-default-profile.conf
@@ -1,2 +1,2 @@
 [Default Profile]
-Permissions=Audio;Bluetooth;Camera;Internet;Location;MediaIndexing;Microphone;NFC;RemovableMedia;UserDirs;WebView
+Permissions=Audio;Bluetooth;Camera;Compatibility;Internet;Location;MediaIndexing;Microphone;NFC;RemovableMedia;UserDirs;WebView

--- a/permissions/Compatibility.permission
+++ b/permissions/Compatibility.permission
@@ -1,0 +1,32 @@
+# -*- mode: sh -*-
+# This provides compatibility for older apps
+# The permission is not shown to user,
+# thus it ***must not*** give access to additional data or hardware resources
+
+# x-sailjail-translation-catalog =
+# x-sailjail-translation-key-description = permission-la-compatibility
+# x-sailjail-description = Compatibility
+# x-sailjail-translation-key-long-description = permission-la-compatibility_description
+# x-sailjail-long-description =
+
+# PDF tools
+private-bin pdfinfo
+private-bin pdftocairo
+private-bin pdftoppm
+private-bin pdftops
+
+# Calligra for office file conversion
+private-bin calligraconverter
+
+# ffmpeg
+private-bin ffmpeg
+private-bin ffprobe
+
+# Package manager
+# Note that this does not allow install or removal
+private-bin rpm
+
+# Basic tools
+private-bin busybox
+private-bin tar
+private-bin which


### PR DESCRIPTION
Add Compatibility permission for default profile. This allows apps to
access selected binaries from /usr/bin. It has been used as a way around
certain library restrictions.

Please check if the list of binaries is sane and if it should have something
more or less. Also please check the descriptions.

See also https://github.com/sailfishos/sailjail/pull/69