### PR TITLE
Allow checking lock state and starting csd for voicecall-ui

### DIFF
--- a/permissions/voicecall-ui.profile
+++ b/permissions/voicecall-ui.profile
@@ -9,4 +9,10 @@ dbus-system.call com.nokia.dsme=com.nokia.dsme.request.*@/com/nokia/dsme/request
 
 dbus-user.call com.jolla.settings=com.jolla.settings.ui.showPage@/com/jolla/settings/ui
 
+# Specials
+dbus-system.talk org.nemomobile.devicelock
+dbus-system.call org.nemomobile.devicelock=org.nemomobile.lipstick.devicelock.state@/org/nemomobile/devicelock
+dbus-user.talk com.jolla.csd
+dbus-user.call com.jolla.csd=com.jolla.csd@/
+
 include /etc/sailjail/permissions/sailfish-policy.inc


### PR DESCRIPTION
Phone application must be able to check lock state and talk to
com.jolla.csd to be able to launch it when a special phone number is
written. As it doesn't really need to access any methods on that bus
name, limit it to something that doesn't matter.