### PR TITLE
Drop voicecall-ui-prestart.profile symlink

### DIFF
--- a/rpm/sailjail-permissions.spec
+++ b/rpm/sailjail-permissions.spec
@@ -26,7 +26,6 @@ make %{?_smp_mflags}
 %install
 %qmake5_install
 
-ln -s voicecall-ui.profile %{buildroot}%{permissions_dir}/voicecall-ui-prestart.profile
 ln -s jolla-camera.profile %{buildroot}%{permissions_dir}/jolla-camera-lockscreen.profile
 
 %files


### PR DESCRIPTION
This is unnecessary after combining voicecall-ui.desktop and voicecall-ui-prestart.desktop.