### PR TITLE
[permissions] Supplement broadcast permissions for UDisksListen. OMP#OS-5687

### DIFF
--- a/permissions/UDisksListen.permission
+++ b/permissions/UDisksListen.permission
@@ -7,6 +7,8 @@
 # x-sailjail-long-description = Permissions to access properties and to listen to property changes on storage devices
 
 # BEG systembus-org.freedesktop.UDisks2.resource
+dbus-system.broadcast org.freedesktop.UDisks2=org.freedesktop.DBus.ObjectManager.*@/*
+dbus-system.broadcast org.freedesktop.UDisks2=org.freedesktop.DBus.Properties.*@/*
 dbus-system.broadcast org.freedesktop.UDisks2=org.freedesktop.UDisks2.*@/*
 dbus-system.broadcast org.freedesktop.UDisks2.*=org.freedesktop.UDisks2.*@/*
 


### PR DESCRIPTION
For the correct synchronization of the partition model, it is necessary to enable the UDisks2 service to listen to the signals of  `org.freedesktop.DBus.ObjectManager.*` and `org.freedesktop.DBus.Properties.*` interfaces.

Without them, the status of the partition is synchronized incorrectly (mounted or unmounted, etc.).