### PR TITLE
[permissions] Remove folder required by WebView from blacklist. OMP#OS-10807

### DIFF
--- a/permissions/WebView.permission
+++ b/permissions/WebView.permission
@@ -31,5 +31,5 @@ dbus-user.broadcast org.nemo.transferengine=org.nemo.transferengine.*@/*
 
 ### INDIRECT/UNKNOWN
 
-# some side effect from some xdg action ?
-whitelist ${HOME}/Desktop
+noblacklist ${HOME}/Desktop
+whitelist   ${HOME}/Desktop


### PR DESCRIPTION
The `${HOME}/Desktop` folder is blacklisted in Base permissions.
Disabling the blacklist for a folder must be before adding the folder to the whitelist.