### PR TITLE
[permissions] Add /var/run to base permissions.

### DIFF
--- a/permissions/Base.permission
+++ b/permissions/Base.permission
@@ -58,6 +58,7 @@ include whitelist-usr-share-common.inc
 whitelist /var/lib/timed
 blacklist /var/lib/timed/shared_events
 blacklist /var/lib/timed/shared_settings
+whitelist /var/run
 # FIXME: /var handling needs more thought
 
 # /etc:


### PR DESCRIPTION
Connman creates /etc/resolv.conf as a symbolic link to /var/run/connman/resolv.conf.