### PR TITLE
[permissions] Remove PDF tools

### DIFF
--- a/permissions/Compatibility.permission
+++ b/permissions/Compatibility.permission
@@ -9,12 +9,6 @@
 # x-sailjail-translation-key-long-description = permission-la-compatibility_description
 # x-sailjail-long-description =
 
-# PDF tools
-private-bin pdfinfo
-private-bin pdftocairo
-private-bin pdftoppm
-private-bin pdftops
-
 # Calligra for office file conversion
 private-bin calligraconverter
 


### PR DESCRIPTION
First off; many thanks for adding this originally.
I really had no idea if i could change over in time for 4.4.
But SeaPrint 1.0 seems to have been a success, so now these are not needed anymore.
I have something like one-and-a-half report that something stopped working compared to 0.9, but they never followed up... so should be fine.

For discussion: could be sensible waiting another minor-version of SFOS before merging.
For discussion 2: I would be open to (try to) contribute to share-as-pdf for Sailfish-Office so Calligraconverter can be dropped, but afaict there is no "neutral ground" to hand over such files. Feel free to poke me in IRC or the forums as well.