### PR TITLE
[sailjail-permissions] Add a voicecall-ui-prestart profile.

### DIFF
--- a/permissions/voicecall-ui-prestart.profile
+++ b/permissions/voicecall-ui-prestart.profile
@@ -1,0 +1,3 @@
+# -*- mode: sh -*-
+dbus-user.own com.jolla.voicecall.ui
+dbus-user.own com.nokia.telephony.callhistory


### PR DESCRIPTION
This allows to declare the prestart voicecall-ui
as owner of the com.jolla.voicecall.ui
and com.nokia.telephony.callhistory interfaces.

This is related to https://forum.sailfishos.org/t/4-4-0-58-tap-missing-call-doesnt-open-phone-app/10819. The problem is arising from the fact that within sailjail, the prestart voicecall-ui cannot register the `com.nokia.telephony.callhistory` service because it's not allowed to own it.

I'm not sure this is the right way to solve the problem though it is efficient ;)