### PR TITLE
[permissions] Allow email to access browser ui. Fixes JB#58786

### DIFF
--- a/permissions/jolla-email.profile
+++ b/permissions/jolla-email.profile
@@ -1,4 +1,7 @@
 # -*- mode: sh -*-
 dbus-user.own com.jolla.email.ui
 
+dbus-user.talk org.sailfishos.browser.ui
+dbus-user.call org.sailfishos.browser.ui=org.sailfishos.browser.ui.*@/ui
+
 include /etc/sailjail/permissions/sailfish-policy.inc


### PR DESCRIPTION
The jolla-email app needs to open and close tabs in the external browser as part of the account creation flow (OAuth2). This change grants access to the org.sailfishos.browser.ui DBus interface for this purpose.