### PR TITLE
[permissions] Add missing MmsEngine permission to Messages. JB#56790

### DIFF
--- a/permissions/Messages.permission
+++ b/permissions/Messages.permission
@@ -25,6 +25,8 @@ whitelist ${HOME}/.cache/commhistory-tmp
 dbus-system.talk org.ofono.SmartMessagingAgent
 dbus-system.talk org.nemomobile.MmsHandler
 dbus-system.broadcast org.nemomobile.MmsHandler=org.nemomobile.MmsHandler.*@/*
+dbus-system.talk org.nemomobile.MmsEngine
+dbus-system.broadcast org.nemomobile.MmsEngine=org.nemomobile.MmsEngine.*@/*
 
 # Roaming checking
 dbus-user.talk com.jolla.Connectiond


### PR DESCRIPTION
The MmsHelper in libcommhistory is using two different mms services which have different services handling them. Other was included while the other was not.

 @Tomin1 @monich 