### PR TITLE
[permissions] Allow contacts to access browser ui. JB#59301

### DIFF
--- a/permissions/jolla-contacts.profile
+++ b/permissions/jolla-contacts.profile
@@ -1,2 +1,5 @@
 # -*- mode: sh -*-
 dbus-user.own com.jolla.contacts.ui
+
+dbus-user.talk org.sailfishos.browser.ui
+dbus-user.call org.sailfishos.browser.ui=org.sailfishos.browser.ui.*@/ui


### PR DESCRIPTION
The jolla-contacts app needs to open and close tabs in the external browser as part of the account creation flow (OAuth2) of the Import Contacts Wizard. This change grants access to the
org.sailfishos.browser.ui DBus interface for this purpose.