### PR TITLE
[sailjail-permissions] Remove disable-passwdmgr.inc. Contributes to JB#59121

### DIFF
--- a/permissions/Base.permission
+++ b/permissions/Base.permission
@@ -26,7 +26,6 @@ include disable-common.inc
 # include disable-devel.inc
 # include disable-exec.inc
 # include disable-interpreters.inc
-include disable-passwdmgr.inc
 # include disable-programs.inc
 # include disable-xdg.inc
 

--- a/rpm/sailjail-permissions.spec
+++ b/rpm/sailjail-permissions.spec
@@ -1,6 +1,6 @@
 Name:     sailjail-permissions
 Summary:  Permissions definitions for Sailjail
-Version:  1.0.0
+Version:  1.1.10
 Release:  1
 License:  BSD
 URL:      https://github.com/sailfishos/sailjail-permissions


### PR DESCRIPTION
Firejail 0.9.72 no longer uses or includes disable-passwdmgr.inc. Having it present in sailjail-permissions causes sailjail to fail to launch with the newer firejail.