### PR TITLE
[sailjail-permissions] Allow access to last position for qtlocation

### DIFF
--- a/permissions/Location.permission
+++ b/permissions/Location.permission
@@ -11,6 +11,9 @@ whitelist /var/lib/location
 
 private-etc location
 
+# allow retrieving and storing last known position
+read-write ${HOME}/.local/share/qtposition-geoclue
+
 include /etc/sailjail/permissions/Sensors.permission
 
 # BEG sessionbus-org.freedesktop.GeoClue.resource


### PR DESCRIPTION
If I understand correctly, the Qt GeoClue plugin stores its last known position in a per-user data file.

Allow reading and writing that file in the Location permission.

For context, see

 - https://github.com/sailfishos/qtlocation/blob/a1c218a04e8e56206fbbbbb8f071eb33484e80a3/src/plugins/position/geoclue/qgeopositioninfosource_geocluemaster.cpp#L82
 - https://github.com/sailfishos/qtlocation/blob/a1c218a04e8e56206fbbbbb8f071eb33484e80a3/src/plugins/position/geoclue/qgeopositioninfosource_geocluemaster.cpp#L104

