### PR TITLE
[sailjail-permissions] Fix some signal tracking rules. JB#63998

### DIFF
--- a/permissions/CommunicationHistory.permission
+++ b/permissions/CommunicationHistory.permission
@@ -14,4 +14,5 @@ dbus-user.broadcast org.nemomobile.CommHistory=org.nemomobile.CommHistory.*@/org
 dbus-user.call org.nemomobile.CommHistory=org.nemomobile.CommHistory.*@/org/nemomobile/CommHistory
 
 dbus-user.own com.nokia.commhistory.*
-dbus-user.broadcast *=com.nokia.commhistory.*@/CommHistoryModel
+# TODO: support * as source once that's supported
+dbus-user.broadcast com.nokia.commhistory.*=com.nokia.commhistory.*@/CommHistoryModel

--- a/permissions/Contacts.permission
+++ b/permissions/Contacts.permission
@@ -22,7 +22,8 @@ dbus-user.talk org.sailfishos.maps
 dbus-user.talk com.jolla.contacts.ui
 
 dbus-user.own org.nemomobile.contacts.sqlite.*
-dbus-user.broadcast *=org.nemomobile.contacts.sqlite.*@/org/nemomobile/contacts/sqlite
+# TODO: support * as source once that's support
+dbus-user.broadcast org.nemomobile.contacts.sqlite.*=org.nemomobile.contacts.sqlite.*@/org/nemomobile/contacts/sqlite
 
 mkdir     ${HOME}/.local/share/system/Contacts
 whitelist ${HOME}/.local/share/system/Contacts

--- a/permissions/Email.permission
+++ b/permissions/Email.permission
@@ -10,7 +10,9 @@
 dbus-user.talk org.qt.messageserver
 dbus-user.talk org.qt.mailstore
 dbus-user.broadcast org.qt.messageserver=org.qt.messageserver.*@/*
-dbus-user.broadcast org.qt.mailstore=org.qt.mailstore.*@/*
+dbus-user.own org.qt.mailstore.*
+# TODO: support * as source once that's support
+dbus-user.broadcast org.qt.mailstore.*=org.qt.mailstore.*@/*
 
 # Messaging framework
 mkdir     ${HOME}/.qmf


### PR DESCRIPTION
Apparently xdg-dbus-proxy doesn't allow '*' as sender, only '.*' to match the service suffix. Thus using here explicit prefix used in messaginframework, libcommhistory and qtcontacts-sqlite.

This is stupid band-aid. The configuration should really just support that generic wildcard.

Disclaimer: so far tested only email (pr there shortly)