### PR TITLE
[permissions] Move profiled access only to voicecall-ui. JB#64411

### DIFF
--- a/permissions/Base.permission
+++ b/permissions/Base.permission
@@ -134,10 +134,6 @@ dbus-user.own       org.sailfishos.coveraction.*
 dbus-user.talk      org.sailfishos.coveraction
 dbus-user.broadcast org.sailfishos.coveraction.*=org.sailfishos.coveraction.*@/*
 # END sessionbus-com.jolla.lipstick.resource
-# BEG sessionbus-com.nokia.profiled.resource
-dbus-user.talk com.nokia.profiled
-dbus-user.broadcast com.nokia.profiled=com.nokia.profiled.*@/*
-# END sessionbus-com.nokia.profiled.resource
 # BEG sessionbus-com.nokia.time.resource
 dbus-user.talk com.nokia.time
 dbus-user.broadcast com.nokia.time=com.nokia.time.*@/*

--- a/permissions/voicecall-ui.profile
+++ b/permissions/voicecall-ui.profile
@@ -15,4 +15,9 @@ dbus-system.call org.nemomobile.devicelock=org.nemomobile.lipstick.devicelock.st
 dbus-user.talk com.jolla.csd
 dbus-user.call com.jolla.csd=com.jolla.csd@/
 
+# BEG sessionbus-com.nokia.profiled.resource
+dbus-user.talk com.nokia.profiled
+dbus-user.broadcast com.nokia.profiled=com.nokia.profiled.*@/*
+# END sessionbus-com.nokia.profiled.resource
+
 include /etc/sailjail/permissions/sailfish-policy.inc


### PR DESCRIPTION
Shouldn't be that much needed generally and libprofile is not harbour allowed either. I'm guessing this existed here because Silica used to track profile for long time though didn't actually use the tracking for anything since 2013.

Even voicecall shouldn't need access to the full api, but keeping it this way for simplicity.